### PR TITLE
add(cli): read-concurrency option for serve

### DIFF
--- a/pkg/usecase/schema.go
+++ b/pkg/usecase/schema.go
@@ -65,7 +65,7 @@ func (x *UseCase) applyInferredSchema(ctx context.Context, objects []model.Objec
 
 	logger := utils.CtxLogger(ctx)
 	logger.Info("importing objects", "source.size", len(requests))
-	records, _, err := importLogRecords(ctx, x.clients, requests)
+	records, _, err := importLogRecords(ctx, x.clients, requests, x.readObjectConcurrency)
 	if err != nil {
 		return err
 	}

--- a/pkg/usecase/usecase.go
+++ b/pkg/usecase/usecase.go
@@ -8,11 +8,18 @@ import (
 type UseCase struct {
 	clients  *infra.Clients
 	metadata *model.MetadataConfig
+
+	readObjectConcurrency int
 }
+
+const (
+	defaultReadObjectConcurrency = 32
+)
 
 func New(clients *infra.Clients, options ...Option) *UseCase {
 	uc := &UseCase{
-		clients: clients,
+		clients:               clients,
+		readObjectConcurrency: defaultReadObjectConcurrency,
 	}
 
 	for _, option := range options {
@@ -27,5 +34,14 @@ type Option func(*UseCase)
 func WithMetadata(metadata *model.MetadataConfig) Option {
 	return func(uc *UseCase) {
 		uc.metadata = metadata
+	}
+}
+
+func WithReadObjectConcurrency(n int) Option {
+	if n < 1 {
+		n = 1
+	}
+	return func(uc *UseCase) {
+		uc.readObjectConcurrency = n
 	}
 }


### PR DESCRIPTION
To control read concurrency of Cloud Storage reader. Default is 32