### PR TITLE
Add concurrency control for BigQuery ingestion

### DIFF
--- a/pkg/domain/model/bigquery.go
+++ b/pkg/domain/model/bigquery.go
@@ -35,6 +35,7 @@ type IngestLog struct {
 	TableSchema  string             `json:"table_schema" bigquery:"table_schema"`
 	LogCount     int                `json:"log_count" bigquery:"log_count"`
 	Success      bool               `json:"success" bigquery:"success"`
+	Error        string             `json:"error" bigquery:"error"`
 }
 
 type LoadLogRaw struct {

--- a/pkg/infra/bq/client.go
+++ b/pkg/infra/bq/client.go
@@ -35,7 +35,10 @@ func New(ctx context.Context, projectID string) (*Client, error) {
 		return nil, goerr.Wrap(err, "failed to create bigquery client").With("projectID", projectID)
 	}
 
-	bqClient, err := bigquery.NewClient(ctx, projectID)
+	bqClient, err := bigquery.NewClient(ctx, projectID,
+		mw.WithMultiplexing(),
+		mw.WithMultiplexPoolLimit(16),
+	)
 	if err != nil {
 		return nil, goerr.Wrap(err, "failed to create bigquery client").With("projectID", projectID)
 	}

--- a/pkg/usecase/usecase.go
+++ b/pkg/usecase/usecase.go
@@ -10,6 +10,7 @@ type UseCase struct {
 	metadata *model.MetadataConfig
 
 	readObjectConcurrency int
+	ingestConcurrency     int
 	enqueueCountLimit     int
 	enqueueSizeLimit      int
 }
@@ -18,12 +19,14 @@ const (
 	defaultReadObjectConcurrency = 32
 	defaultEnqueueCountLimit     = 128
 	defaultEnqueueSizeLimit      = 4 // MiB
+	defaultIngestConcurrency     = 16
 )
 
 func New(clients *infra.Clients, options ...Option) *UseCase {
 	uc := &UseCase{
 		clients:               clients,
 		readObjectConcurrency: defaultReadObjectConcurrency,
+		ingestConcurrency:     defaultIngestConcurrency,
 		enqueueCountLimit:     defaultEnqueueCountLimit,
 		enqueueSizeLimit:      defaultEnqueueSizeLimit,
 	}


### PR DESCRIPTION
It's trial to have multiplex ingestion for BigQuery