### PR TITLE
add(state): Add state TTL duration setting for state management

### DIFF
--- a/pkg/controller/cmd/serve.go
+++ b/pkg/controller/cmd/serve.go
@@ -25,6 +25,7 @@ func serveCommand() *cli.Command {
 		readConcurrency   int
 		ingestConcurrency int
 		stateTimeout      time.Duration
+		stateTTL          time.Duration
 
 		bq       config.BigQuery
 		policy   config.Policy
@@ -68,6 +69,13 @@ func serveCommand() *cli.Command {
 				Destination: &stateTimeout,
 				Value:       30 * time.Minute,
 			},
+			&cli.DurationFlag{
+				Name:        "state-ttl",
+				EnvVars:     []string{"SWARM_STATE_TTL"},
+				Usage:       "TTL duration to keep state",
+				Destination: &stateTTL,
+				Value:       7 * 24 * time.Hour,
+			},
 			&cli.StringFlag{
 				Name:        "firestore-project-id",
 				EnvVars:     []string{"SWARM_FIRESTORE_PROJECT_ID"},
@@ -90,6 +98,7 @@ func serveCommand() *cli.Command {
 					"read-concurrency", readConcurrency,
 					"ingest-concurrency", ingestConcurrency,
 					"state-timeout", stateTimeout.String(),
+					"state-ttl", stateTTL.String(),
 					"firestore-project-id", firestoreProject,
 					"firestore-database-id", firestoreDatabase,
 
@@ -139,6 +148,7 @@ func serveCommand() *cli.Command {
 			ucOptions := []usecase.Option{
 				usecase.WithIngestConcurrency(ingestConcurrency),
 				usecase.WithStateTimeout(stateTimeout),
+				usecase.WithStateTTL(stateTTL),
 			}
 
 			if meta, err := metadata.Configure(); err != nil {

--- a/pkg/domain/model/state.go
+++ b/pkg/domain/model/state.go
@@ -13,6 +13,7 @@ type State struct {
 	CreatedAt time.Time       `firestore:"created_at"`
 	UpdatedAt time.Time       `firestore:"updated_at"`
 	ExpiresAt time.Time       `firestore:"expires_at"`
+	TTL       time.Time       `firestore:"ttl"`
 }
 
 func (x *State) Acquired(now time.Time) bool {
@@ -25,6 +26,6 @@ func (x *State) Acquired(now time.Time) bool {
 		return true
 
 	default:
-		panic("unexpected state type")
+		panic("unexpected state type: " + string(x.State))
 	}
 }

--- a/pkg/usecase/state.go
+++ b/pkg/usecase/state.go
@@ -19,6 +19,7 @@ func (x *UseCase) GetOrCreateState(ctx context.Context, msgType types.MsgType, i
 		CreatedAt: now,
 		UpdatedAt: now,
 		ExpiresAt: now.Add(x.stateTimeout),
+		TTL:       now.Add(x.stateTTL),
 	}
 
 	// If database is not available, return acquired state always

--- a/pkg/usecase/usecase.go
+++ b/pkg/usecase/usecase.go
@@ -15,7 +15,12 @@ type UseCase struct {
 	ingestConcurrency     int
 	enqueueCountLimit     int
 	enqueueSizeLimit      int
-	stateTimeout          time.Duration
+
+	// stateTimeout is a duration to wait for state transition. Even if the state is not changed, other process can acquire the state after this duration.
+	stateTimeout time.Duration
+
+	// stateTTL is a duration to keep the state. After this duration, the state is deleted from database. This is used to avoid re-process of the same message.
+	stateTTL time.Duration
 }
 
 const (
@@ -24,6 +29,7 @@ const (
 	defaultEnqueueSizeLimit      = 4 // MiB
 	defaultIngestConcurrency     = 64
 	defaultStateTimeout          = 30 * time.Minute
+	defaultStateTTL              = 7 * 24 * time.Hour
 )
 
 func New(clients *infra.Clients, options ...Option) *UseCase {
@@ -34,6 +40,7 @@ func New(clients *infra.Clients, options ...Option) *UseCase {
 		enqueueCountLimit:     defaultEnqueueCountLimit,
 		enqueueSizeLimit:      defaultEnqueueSizeLimit,
 		stateTimeout:          defaultStateTimeout,
+		stateTTL:              defaultStateTTL,
 	}
 
 	for _, option := range options {
@@ -90,5 +97,11 @@ func WithIngestConcurrency(n int) Option {
 func WithStateTimeout(d time.Duration) Option {
 	return func(uc *UseCase) {
 		uc.stateTimeout = d
+	}
+}
+
+func WithStateTTL(d time.Duration) Option {
+	return func(uc *UseCase) {
+		uc.stateTTL = d
 	}
 }


### PR DESCRIPTION
For life cycle management in firestore, create a new field `ttl` to use TTL policy.

See detail from https://firebase.google.com/docs/firestore/ttl