### PR TITLE
add(cli, server): Memory limit option

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	cloud.google.com/go/firestore v1.15.0
 	cloud.google.com/go/pubsub v1.37.0
 	cloud.google.com/go/storage v1.39.1
+	github.com/dustin/go-humanize v1.0.1
 	github.com/fatih/color v1.16.0
 	github.com/getsentry/sentry-go v0.27.0
 	github.com/go-chi/chi/v5 v5.0.12

--- a/pkg/controller/cmd/serve.go
+++ b/pkg/controller/cmd/serve.go
@@ -8,6 +8,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/dustin/go-humanize"
 	"github.com/m-mizutani/goerr"
 	"github.com/m-mizutani/swarm/pkg/controller/cmd/config"
 	"github.com/m-mizutani/swarm/pkg/controller/server"
@@ -171,7 +172,17 @@ func serveCommand() *cli.Command {
 			}
 
 			uc := usecase.New(infra.New(infraOptions...), ucOptions...)
-			srv := server.New(uc)
+
+			var serverOptions []server.Option
+			if memoryLimit != "" {
+				limit, err := humanize.ParseBytes(memoryLimit)
+				if err != nil {
+					return goerr.Wrap(err, "invalid memory limit option")
+				}
+				serverOptions = append(serverOptions, server.WithMemoryLimit(limit))
+			}
+
+			srv := server.New(uc, serverOptions...)
 
 			// Listen srv on addr
 			httpServer := &http.Server{

--- a/pkg/controller/cmd/serve.go
+++ b/pkg/controller/cmd/serve.go
@@ -34,6 +34,8 @@ func serveCommand() *cli.Command {
 
 		firestoreProject  string
 		firestoreDatabase string
+
+		memoryLimit string
 	)
 
 	return &cli.Command{
@@ -88,6 +90,12 @@ func serveCommand() *cli.Command {
 				Usage:       "Database ID of Firestore (To manage state)",
 				Destination: &firestoreDatabase,
 			},
+			&cli.StringFlag{
+				Name:        "memory-limit",
+				EnvVars:     []string{"SWARM_MEMORY_LIMIT"},
+				Usage:       "Memory limit for each process. If it exceeds the limit, the process return 429 too many requests error. (e.g. 1GiB)",
+				Destination: &memoryLimit,
+			},
 		}, bq.Flags(), policy.Flags(), metadata.Flags(), sentry.Flags()),
 		Action: func(c *cli.Context) error {
 			ctx := c.Context
@@ -101,6 +109,7 @@ func serveCommand() *cli.Command {
 					"state-ttl", stateTTL.String(),
 					"firestore-project-id", firestoreProject,
 					"firestore-database-id", firestoreDatabase,
+					"memory-limit", memoryLimit,
 
 					"bigquery", &bq,
 					"policy", &policy,


### PR DESCRIPTION
# Why

#23 

# Changes

- Add `--memory-limit` option
- Add middleware for `MemoryLimit` and applying to `/event` prefix path
- If memory limit is set and `runtime.MemStats.Sys` is exceeded, it returns HTTP 429 error