### PR TITLE
Separate ingest concurrency to table and records

### DIFF
--- a/pkg/controller/cmd/serve.go
+++ b/pkg/controller/cmd/serve.go
@@ -22,11 +22,12 @@ import (
 
 func serveCommand() *cli.Command {
 	var (
-		addr              string
-		readConcurrency   int
-		ingestConcurrency int
-		stateTimeout      time.Duration
-		stateTTL          time.Duration
+		addr                    string
+		readConcurrency         int
+		ingestTableConcurrency  int
+		ingestRecordConcurrency int
+		stateTimeout            time.Duration
+		stateTTL                time.Duration
 
 		bq       config.BigQuery
 		policy   config.Policy
@@ -59,11 +60,18 @@ func serveCommand() *cli.Command {
 				Value:       32,
 			},
 			&cli.IntFlag{
-				Name:        "ingest-concurrency",
-				EnvVars:     []string{"SWARM_INGEST_CONCURRENCY"},
-				Usage:       "Number of concurrent ingest to BigQuery",
-				Destination: &ingestConcurrency,
-				Value:       32,
+				Name:        "ingest-table-concurrency",
+				EnvVars:     []string{"SWARM_INGEST_TABLE_CONCURRENCY"},
+				Usage:       "Number of concurrent ingest to BigQuery (for tables)",
+				Destination: &ingestTableConcurrency,
+				Value:       16,
+			},
+			&cli.IntFlag{
+				Name:        "ingest-record-concurrency",
+				EnvVars:     []string{"SWARM_INGEST_RECORD_CONCURRENCY"},
+				Usage:       "Number of concurrent ingest to BigQuery (for tables)",
+				Destination: &ingestRecordConcurrency,
+				Value:       16,
 			},
 			&cli.DurationFlag{
 				Name:        "state-timeout",
@@ -105,7 +113,8 @@ func serveCommand() *cli.Command {
 				slog.Group("config",
 					"addr", addr,
 					"read-concurrency", readConcurrency,
-					"ingest-concurrency", ingestConcurrency,
+					"ingest-table-concurrency", ingestTableConcurrency,
+					"ingest-record-concurrency", ingestRecordConcurrency,
 					"state-timeout", stateTimeout.String(),
 					"state-ttl", stateTTL.String(),
 					"firestore-project-id", firestoreProject,
@@ -156,7 +165,8 @@ func serveCommand() *cli.Command {
 			}
 
 			ucOptions := []usecase.Option{
-				usecase.WithIngestConcurrency(ingestConcurrency),
+				usecase.WithIngestTableConcurrency(ingestTableConcurrency),
+				usecase.WithIngestRecordConcurrency(ingestRecordConcurrency),
 				usecase.WithStateTimeout(stateTimeout),
 				usecase.WithStateTTL(stateTTL),
 			}

--- a/pkg/usecase/load_test.go
+++ b/pkg/usecase/load_test.go
@@ -146,12 +146,20 @@ func TestIngestRecordBigNum(t *testing.T) {
 		})
 	}
 
-	resp := gt.R1(usecase.IngestRecords(ctx, bqMock, dst, records)).NoError(t)
+	resp := gt.R1(usecase.IngestRecords(ctx, bqMock, dst, records, 10)).NoError(t)
 	gt.True(t, resp.Success)
 
 	gt.A(t, bqMock.Inserted).Length(4)
-	gt.A(t, bqMock.Inserted[0].Data).Length(256)
-	gt.A(t, bqMock.Inserted[1].Data).Length(256)
-	gt.A(t, bqMock.Inserted[2].Data).Length(256)
-	gt.A(t, bqMock.Inserted[3].Data).Length(233)
+	c256, c233 := 0, 0
+	for _, r := range bqMock.Inserted {
+		if len(r.Data) == 256 {
+			c256++
+		} else if len(r.Data) == 233 {
+			c233++
+		} else {
+			t.Errorf("Unexpected data length: %d", len(r.Data))
+		}
+	}
+	gt.N(t, c256).Equal(3)
+	gt.N(t, c233).Equal(1)
 }

--- a/pkg/usecase/usecase.go
+++ b/pkg/usecase/usecase.go
@@ -11,10 +11,11 @@ type UseCase struct {
 	clients  *infra.Clients
 	metadata *model.MetadataConfig
 
-	readObjectConcurrency int
-	ingestConcurrency     int
-	enqueueCountLimit     int
-	enqueueSizeLimit      int
+	readObjectConcurrency   int
+	ingestTableConcurrency  int
+	ingestRecordConcurrency int
+	enqueueCountLimit       int
+	enqueueSizeLimit        int
 
 	// stateTimeout is a duration to wait for state transition. Even if the state is not changed, other process can acquire the state after this duration.
 	stateTimeout time.Duration
@@ -24,23 +25,25 @@ type UseCase struct {
 }
 
 const (
-	defaultReadObjectConcurrency = 32
-	defaultEnqueueCountLimit     = 128
-	defaultEnqueueSizeLimit      = 4 // MiB
-	defaultIngestConcurrency     = 64
-	defaultStateTimeout          = 30 * time.Minute
-	defaultStateTTL              = 7 * 24 * time.Hour
+	defaultReadObjectConcurrency   = 32
+	defaultEnqueueCountLimit       = 128
+	defaultEnqueueSizeLimit        = 4 // MiB
+	defaultIngestTableConcurrency  = 8
+	defaultIngestRecordConcurrency = 8
+	defaultStateTimeout            = 30 * time.Minute
+	defaultStateTTL                = 7 * 24 * time.Hour
 )
 
 func New(clients *infra.Clients, options ...Option) *UseCase {
 	uc := &UseCase{
-		clients:               clients,
-		readObjectConcurrency: defaultReadObjectConcurrency,
-		ingestConcurrency:     defaultIngestConcurrency,
-		enqueueCountLimit:     defaultEnqueueCountLimit,
-		enqueueSizeLimit:      defaultEnqueueSizeLimit,
-		stateTimeout:          defaultStateTimeout,
-		stateTTL:              defaultStateTTL,
+		clients:                 clients,
+		readObjectConcurrency:   defaultReadObjectConcurrency,
+		ingestTableConcurrency:  defaultIngestTableConcurrency,
+		ingestRecordConcurrency: defaultIngestRecordConcurrency,
+		enqueueCountLimit:       defaultEnqueueCountLimit,
+		enqueueSizeLimit:        defaultEnqueueSizeLimit,
+		stateTimeout:            defaultStateTimeout,
+		stateTTL:                defaultStateTTL,
 	}
 
 	for _, option := range options {
@@ -85,12 +88,21 @@ func WithEnqueueSizeLimit(n int) Option {
 	}
 }
 
-func WithIngestConcurrency(n int) Option {
+func WithIngestTableConcurrency(n int) Option {
 	if n < 1 {
 		n = 1
 	}
 	return func(uc *UseCase) {
-		uc.ingestConcurrency = n
+		uc.ingestTableConcurrency = n
+	}
+}
+
+func WithIngestRecordConcurrency(n int) Option {
+	if n < 1 {
+		n = 1
+	}
+	return func(uc *UseCase) {
+		uc.ingestRecordConcurrency = n
 	}
 }
 


### PR DESCRIPTION
`--ingest-concurrency` is separated into 

- `--ingest-table-concurrency`
- `--ingest-record-concurrency`