### PR TITLE
Implement migrate subcommand

### DIFF
--- a/pkg/controller/cmd/cli.go
+++ b/pkg/controller/cmd/cli.go
@@ -33,6 +33,7 @@ func Run(argv []string) error {
 			clientCommand(),
 			schemaCommand(),
 			enqueueCommand(),
+			migrateCommand(),
 		},
 	}
 

--- a/pkg/controller/cmd/config/bigquery.go
+++ b/pkg/controller/cmd/config/bigquery.go
@@ -11,7 +11,7 @@ import (
 )
 
 type BigQuery struct {
-	projectID string
+	projectID types.GoogleProjectID
 }
 
 func (x *BigQuery) Flags() []cli.Flag {
@@ -20,7 +20,7 @@ func (x *BigQuery) Flags() []cli.Flag {
 			Name:        "bigquery-project-id",
 			Usage:       "Google Cloud project ID for BigQuery",
 			EnvVars:     []string{"SWARM_BIGQUERY_PROJECT_ID"},
-			Destination: &x.projectID,
+			Destination: (*string)(&x.projectID),
 		},
 	}
 }
@@ -33,8 +33,12 @@ func (x *BigQuery) Configure(ctx context.Context) (*bq.Client, error) {
 	return bq.New(ctx, x.projectID)
 }
 
+func (x *BigQuery) ProjectID() types.GoogleProjectID {
+	return x.projectID
+}
+
 func (x *BigQuery) LogValue() slog.Value {
 	return slog.GroupValue(
-		slog.String("projectID", x.projectID),
+		slog.Any("projectID", x.projectID),
 	)
 }

--- a/pkg/controller/cmd/migrate.go
+++ b/pkg/controller/cmd/migrate.go
@@ -1,0 +1,136 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"text/template"
+
+	"github.com/m-mizutani/goerr"
+	"github.com/m-mizutani/swarm/pkg/domain/model"
+	"github.com/m-mizutani/swarm/pkg/domain/types"
+	"github.com/m-mizutani/swarm/pkg/infra"
+	"github.com/m-mizutani/swarm/pkg/infra/bq"
+	"github.com/m-mizutani/swarm/pkg/usecase"
+	"github.com/urfave/cli/v2"
+)
+
+func migrateCommand() *cli.Command {
+	var (
+		srcID     string
+		dstID     string
+		partition types.BQPartition
+		query     string
+	)
+
+	const (
+		defaultQuery = "INSERT `{{.dst}}` SELECT * FROM `{{.src}}`"
+	)
+
+	return &cli.Command{
+		Name:    "migrate",
+		Aliases: []string{"m"},
+		Usage:   "Copy schema and data from source table to destination table",
+		Flags: mergeFlags([]cli.Flag{
+			&cli.StringFlag{
+				Name:        "src",
+				Aliases:     []string{"s"},
+				Usage:       "Source table ID (<project>.<dataset>.<table>)",
+				EnvVars:     []string{"SWARM_MIGRATE_SRC"},
+				Destination: &srcID,
+				Required:    true,
+			},
+
+			&cli.StringFlag{
+				Name:        "dst",
+				Aliases:     []string{"d"},
+				Usage:       "Destination table ID (<project>.<dataset>.<table>)",
+				EnvVars:     []string{"SWARM_MIGRATE_DST"},
+				Destination: &dstID,
+				Required:    true,
+			},
+			&cli.StringFlag{
+				Name:        "partition-type",
+				Aliases:     []string{"p"},
+				Usage:       "Time partition type of destination table [hour|day|month|year]",
+				EnvVars:     []string{"SWARM_MIGRATE_PARTITION_TYPE"},
+				Destination: (*string)(&partition),
+			},
+			&cli.StringFlag{
+				Name:        "query",
+				Aliases:     []string{"q"},
+				Usage:       "Query to copy data",
+				EnvVars:     []string{"SWARM_QUERY"},
+				Destination: &query,
+				Value:       defaultQuery,
+			},
+		}),
+
+		Action: func(c *cli.Context) error {
+			tmpl, err := template.New("query").Parse(query)
+			if err != nil {
+				return goerr.Wrap(err, "failed to parse query template")
+			}
+			args := map[string]any{
+				"src": srcID,
+				"dst": dstID,
+			}
+			var q bytes.Buffer
+			if err := tmpl.Execute(&q, args); err != nil {
+				return goerr.Wrap(err, "failed to render query template")
+			}
+
+			srcTable, err := parseBigQueryTableID(srcID)
+			if err != nil {
+				return err
+			}
+			dstTable, err := parseBigQueryTableID(dstID)
+			if err != nil {
+				return err
+			}
+
+			if srcTable.Project != dstTable.Project {
+				return goerr.Wrap(types.ErrInvalidOption, "source and destination table must be in the same project")
+			}
+
+			bqClient, err := bq.New(c.Context, srcTable.Project)
+			if err != nil {
+				return err
+			}
+			clients := infra.New(
+				infra.WithBigQuery(bqClient),
+			)
+			uc := usecase.New(clients)
+
+			src := &model.BigQueryDest{
+				Dataset: srcTable.DatasetID,
+				Table:   srcTable.TableID,
+			}
+			dst := &model.BigQueryDest{
+				Dataset:   dstTable.DatasetID,
+				Table:     dstTable.TableID,
+				Partition: partition,
+			}
+
+			return uc.Migrate(c.Context, src, dst, q.String())
+		},
+	}
+}
+
+type bqTable struct {
+	Project   types.GoogleProjectID
+	DatasetID types.BQDatasetID
+	TableID   types.BQTableID
+}
+
+func parseBigQueryTableID(id string) (*bqTable, error) {
+	parts := strings.Split(id, ".")
+	if len(parts) != 3 {
+		return nil, goerr.Wrap(types.ErrInvalidOption, "invalid table ID").With("id", id)
+	}
+
+	return &bqTable{
+		Project:   types.GoogleProjectID(parts[0]),
+		DatasetID: types.BQDatasetID(parts[1]),
+		TableID:   types.BQTableID(parts[2]),
+	}, nil
+}

--- a/pkg/domain/types/errors.go
+++ b/pkg/domain/types/errors.go
@@ -18,6 +18,7 @@ var (
 	ErrNoPolicyResult      = goerr.New("no policy result")
 	ErrInvalidPolicyResult = goerr.New("invalid policy result")
 	ErrStateNotFound       = goerr.New("state not found")
+	ErrTableNotFound       = goerr.New("table not found")
 
 	// Assertion error
 	ErrAssertion = goerr.New("assertion error")

--- a/pkg/domain/types/types.go
+++ b/pkg/domain/types/types.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"strings"
 
+	"cloud.google.com/go/bigquery"
 	"github.com/google/uuid"
 	"github.com/m-mizutani/goerr"
 )
@@ -54,6 +55,20 @@ const (
 	BQPartitionMonth BQPartition = "month"
 	BQPartitionYear  BQPartition = "year"
 )
+
+func (x BQPartition) Type() bigquery.TimePartitioningType {
+	mapping := map[BQPartition]bigquery.TimePartitioningType{
+		BQPartitionHour:  bigquery.HourPartitioningType,
+		BQPartitionDay:   bigquery.DayPartitioningType,
+		BQPartitionMonth: bigquery.MonthPartitioningType,
+		BQPartitionYear:  bigquery.YearPartitioningType,
+	}
+
+	if v, ok := mapping[x]; ok {
+		return v
+	}
+	return ""
+}
 
 type CSBucket string
 type CSObjectID string

--- a/pkg/infra/bq/client_test.go
+++ b/pkg/infra/bq/client_test.go
@@ -51,7 +51,7 @@ func TestInsert(t *testing.T) {
 	log2 := model.LogRecord{ID: "p2", Timestamp: time.Now(), Data: d2}
 	log3 := model.LogRecord{ID: "p3", Timestamp: time.Now(), Data: d3}
 
-	client := gt.R1(bq.New(ctx, projectID)).NoError(t)
+	client := gt.R1(bq.New(ctx, types.GoogleProjectID(projectID))).NoError(t)
 
 	var merged bigquery.Schema
 	t.Run("Insert first data", func(t *testing.T) {

--- a/pkg/usecase/bigquery_test.go
+++ b/pkg/usecase/bigquery_test.go
@@ -18,7 +18,7 @@ func TestCreateOrUpdateTable(t *testing.T) {
 	bqDataset := utils.LoadEnv(t, "TEST_BIGQUERY_DATASET_ID")
 
 	ctx := context.Background()
-	bqClient := gt.R1(bq.New(ctx, bqProject)).NoError(t)
+	bqClient := gt.R1(bq.New(ctx, types.GoogleProjectID(bqProject))).NoError(t)
 
 	tableID := time.Now().Format("create_test_20060102_150405")
 

--- a/pkg/usecase/load_test.go
+++ b/pkg/usecase/load_test.go
@@ -28,7 +28,7 @@ func TestLoadDataByObject(t *testing.T) {
 	policyDir := utils.LoadEnv(t, "TEST_POLICY_DIR")
 
 	ctx := context.Background()
-	bqClient := gt.R1(bq.New(ctx, bqProject)).NoError(t)
+	bqClient := gt.R1(bq.New(ctx, types.GoogleProjectID(bqProject))).NoError(t)
 	csClient := gt.R1(cs.New(ctx)).NoError(t)
 	pClient := gt.R1(policy.New(policy.WithDir(policyDir))).NoError(t)
 	meta := model.NewMetadataConfig(types.BQDatasetID(bqDataset), types.BQTableID(tableID))

--- a/pkg/usecase/migrate.go
+++ b/pkg/usecase/migrate.go
@@ -1,0 +1,73 @@
+package usecase
+
+import (
+	"context"
+
+	"cloud.google.com/go/bigquery"
+	"github.com/m-mizutani/bqs"
+	"github.com/m-mizutani/goerr"
+	"github.com/m-mizutani/swarm/pkg/domain/model"
+	"github.com/m-mizutani/swarm/pkg/domain/types"
+	"github.com/m-mizutani/swarm/pkg/utils"
+)
+
+func (x *UseCase) Migrate(ctx context.Context, src, dst *model.BigQueryDest, query string) error {
+	if err := x.migrateTable(ctx, src, dst); err != nil {
+		return err
+	}
+
+	utils.CtxLogger(ctx).Info("migrating data", "src", src, "dst", dst, "query", query)
+	if _, err := x.clients.BigQuery().Query(ctx, query); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (x *UseCase) migrateTable(ctx context.Context, src, dst *model.BigQueryDest) error {
+	srcMD, err := x.clients.BigQuery().GetMetadata(ctx, src.Dataset, src.Table)
+	if err != nil {
+		return err
+	}
+	if srcMD == nil {
+		return goerr.Wrap(types.ErrTableNotFound, "source table not found").With("dataset", src.Dataset).With("table", src.Table)
+	}
+
+	dstMD, err := x.clients.BigQuery().GetMetadata(ctx, dst.Dataset, dst.Table)
+	if err != nil {
+		return err
+	}
+	if dstMD == nil {
+		md := &bigquery.TableMetadata{
+			Schema: srcMD.Schema,
+			Name:   dst.Table.String(),
+			TimePartitioning: &bigquery.TimePartitioning{
+				Field: "timestamp",
+				Type:  dst.Partition.Type(),
+			},
+		}
+		utils.CtxLogger(ctx).Info("creating new dst table", "dataset", dst.Dataset, "table", dst.Table)
+
+		return x.clients.BigQuery().CreateTable(ctx, dst.Dataset, dst.Table, md)
+	}
+
+	mergedSchema, err := bqs.Merge(srcMD.Schema, dstMD.Schema)
+	if err != nil {
+		return goerr.Wrap(err, "can not merge schema")
+	}
+
+	if bqs.Equal(srcMD.Schema, mergedSchema) {
+		utils.CtxLogger(ctx).Info("dst table exists and no need to update schema", "dataset", dst.Dataset, "table", dst.Table)
+		return nil
+	}
+
+	utils.CtxLogger(ctx).Info("updating dst table schema", "dataset", dst.Dataset, "table", dst.Table)
+	update := bigquery.TableMetadataToUpdate{
+		Schema: mergedSchema,
+	}
+	if err := x.clients.BigQuery().UpdateTable(ctx, dst.Dataset, dst.Table, update, dstMD.ETag); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/usecase/migrate_test.go
+++ b/pkg/usecase/migrate_test.go
@@ -1,0 +1,155 @@
+package usecase_test
+
+import (
+	"context"
+	"testing"
+
+	"cloud.google.com/go/bigquery"
+	"github.com/m-mizutani/gt"
+	"github.com/m-mizutani/swarm/pkg/domain/model"
+	"github.com/m-mizutani/swarm/pkg/infra"
+	"github.com/m-mizutani/swarm/pkg/infra/bq"
+	"github.com/m-mizutani/swarm/pkg/usecase"
+)
+
+func TestMigrate(t *testing.T) {
+	src := model.BigQueryDest{
+		Dataset: "src_dataset",
+		Table:   "src_table",
+	}
+	dst := model.BigQueryDest{
+		Dataset: "dst_dataset",
+		Table:   "dst_table",
+	}
+
+	testCases := map[string]struct {
+		metadata   []*bigquery.TableMetadata
+		queryCount int
+		isErr      bool
+		testMock   func(*bq.GeneralMock)
+	}{
+		"migrate to new table": {
+			metadata: []*bigquery.TableMetadata{
+				{
+					Schema: []*bigquery.FieldSchema{
+						{Name: "name", Type: bigquery.StringFieldType},
+						{Name: "age", Type: bigquery.IntegerFieldType},
+					},
+				},
+			},
+			queryCount: 1,
+			isErr:      false,
+			testMock: func(mock *bq.GeneralMock) {
+				gt.A(t, mock.CreatedTable).Length(1)
+				gt.Equal(t, mock.CreatedTable[0].Dataset, "dst_dataset")
+				gt.Equal(t, mock.CreatedTable[0].Table, "dst_table")
+				schema := mock.CreatedTable[0].MD.Schema
+				gt.A(t, schema).Length(2).At(0, func(t testing.TB, v *bigquery.FieldSchema) {
+					gt.Equal(t, v.Name, "name")
+					gt.Equal(t, v.Type, bigquery.StringFieldType)
+				}).At(1, func(t testing.TB, v *bigquery.FieldSchema) {
+					gt.Equal(t, v.Name, "age")
+					gt.Equal(t, v.Type, bigquery.IntegerFieldType)
+				})
+			},
+		},
+		"migrate to existing table, schema is same": {
+			metadata: []*bigquery.TableMetadata{
+				{
+					Schema: []*bigquery.FieldSchema{
+						{Name: "name", Type: bigquery.StringFieldType},
+						{Name: "age", Type: bigquery.IntegerFieldType},
+					},
+				},
+				{
+					Schema: []*bigquery.FieldSchema{
+						{Name: "name", Type: bigquery.StringFieldType},
+						{Name: "age", Type: bigquery.IntegerFieldType},
+					},
+				},
+			},
+			queryCount: 1,
+			isErr:      false,
+			testMock: func(mock *bq.GeneralMock) {
+				gt.A(t, mock.UpdatedTable).Length(0)
+			},
+		},
+		"migrate to existing table, schema is different": {
+			metadata: []*bigquery.TableMetadata{
+				{
+					Schema: []*bigquery.FieldSchema{
+						{Name: "name", Type: bigquery.StringFieldType},
+						{Name: "age", Type: bigquery.IntegerFieldType},
+					},
+				},
+
+				{
+					Schema: []*bigquery.FieldSchema{
+						{Name: "name", Type: bigquery.StringFieldType},
+						{Name: "address", Type: bigquery.StringFieldType},
+					},
+					ETag: "xxx",
+				},
+			},
+			queryCount: 1,
+			isErr:      false,
+			testMock: func(mock *bq.GeneralMock) {
+				gt.A(t, mock.UpdatedTable).Length(1)
+				gt.Equal(t, mock.UpdatedTable[0].Dataset, "dst_dataset")
+				gt.Equal(t, mock.UpdatedTable[0].Table, "dst_table")
+				gt.Equal(t, mock.UpdatedTable[0].ETag, "xxx")
+
+				schema := mock.UpdatedTable[0].MD.Schema
+				gt.A(t, schema).Length(3).At(0, func(t testing.TB, v *bigquery.FieldSchema) {
+					gt.Equal(t, v.Name, "name")
+					gt.Equal(t, v.Type, bigquery.StringFieldType)
+				}).At(1, func(t testing.TB, v *bigquery.FieldSchema) {
+					gt.Equal(t, v.Name, "address")
+					gt.Equal(t, v.Type, bigquery.StringFieldType)
+				}).At(2, func(t testing.TB, v *bigquery.FieldSchema) {
+					gt.Equal(t, v.Name, "age")
+					gt.Equal(t, v.Type, bigquery.IntegerFieldType)
+				})
+			},
+		},
+		"conflict schema": {
+			metadata: []*bigquery.TableMetadata{
+				{
+					Schema: []*bigquery.FieldSchema{
+						{Name: "name", Type: bigquery.StringFieldType},
+						{Name: "age", Type: bigquery.IntegerFieldType},
+					},
+				},
+				{
+					Schema: []*bigquery.FieldSchema{
+						{Name: "name", Type: bigquery.StringFieldType},
+						{Name: "age", Type: bigquery.StringFieldType},
+					},
+				},
+			},
+			queryCount: 0,
+			isErr:      true,
+		},
+	}
+
+	for title, tc := range testCases {
+		t.Run(title, func(t *testing.T) {
+			mock := bq.NewGeneralMock()
+			mock.Metadata = tc.metadata
+
+			uc := usecase.New(infra.New(infra.WithBigQuery(mock)))
+			ctx := context.Background()
+
+			err := uc.Migrate(ctx, &src, &dst, "SELECT * FROM src_table")
+			if tc.isErr {
+				gt.Error(t, err)
+				return
+			}
+
+			gt.A(t, mock.Queries).Length(tc.queryCount)
+			if tc.testMock != nil {
+				tc.testMock(mock)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`migrate` copy schema and data from source table to destination table. If table does not exist, it will create a new table. If table exists and schemas are different, it will update schema of destination table.