### PR TITLE
Use managed stream concurrency and reduce open/close frequency of stream

### DIFF
--- a/pkg/domain/interfaces/infra.go
+++ b/pkg/domain/interfaces/infra.go
@@ -17,10 +17,16 @@ type BigQueryIterator interface {
 
 type BigQuery interface {
 	Query(ctx context.Context, query string) (BigQueryIterator, error)
-	Insert(ctx context.Context, datasetID types.BQDatasetID, tableID types.BQTableID, schema bigquery.Schema, data []any) error
+	NewStream(ctx context.Context, datasetID types.BQDatasetID, tableID types.BQTableID, schema bigquery.Schema) (BigQueryStream, error)
+
 	GetMetadata(ctx context.Context, dataset types.BQDatasetID, table types.BQTableID) (*bigquery.TableMetadata, error)
 	UpdateTable(ctx context.Context, dataset types.BQDatasetID, table types.BQTableID, md bigquery.TableMetadataToUpdate, eTag string) error
 	CreateTable(ctx context.Context, dataset types.BQDatasetID, table types.BQTableID, md *bigquery.TableMetadata) error
+}
+
+type BigQueryStream interface {
+	Insert(ctx context.Context, data []any) error
+	Close() error
 }
 
 type PubSub interface {

--- a/pkg/domain/types/errors.go
+++ b/pkg/domain/types/errors.go
@@ -24,5 +24,6 @@ var (
 	ErrAssertion = goerr.New("assertion error")
 
 	// Normal error
-	ErrBlockingPubSub = goerr.New("blocking pubsub ack")
+	ErrBlockingPubSub   = goerr.New("blocking pubsub ack")
+	ErrSchemaNotMatched = goerr.New("schema not matched")
 )

--- a/pkg/infra/bq/client.go
+++ b/pkg/infra/bq/client.go
@@ -88,6 +88,10 @@ func backoff(ctx context.Context, callback func(n int) (done bool, err error)) e
 	}
 }
 
+func (x *Client) NewStream(ctx context.Context, datasetID types.BQDatasetID, tableID types.BQTableID, schema bigquery.Schema) (interfaces.BigQueryStream, error) {
+	return newStream(ctx, x.mwClient, x.projectID, datasetID, tableID, schema)
+}
+
 func (x *Client) Insert(ctx context.Context, datasetID types.BQDatasetID, tableID types.BQTableID, schema bigquery.Schema, data []any) error {
 	convertedSchema, err := adapt.BQSchemaToStorageTableSchema(schema)
 	if err != nil {

--- a/pkg/infra/bq/mock.go
+++ b/pkg/infra/bq/mock.go
@@ -32,10 +32,14 @@ func NewMock() *Mock {
 var _ interfaces.BigQuery = &Mock{}
 
 type MockStream struct {
+	mutex    sync.Mutex
 	Inserted [][]any
 }
 
 func (x *MockStream) Insert(ctx context.Context, data []any) error {
+	x.mutex.Lock()
+	defer x.mutex.Unlock()
+
 	x.Inserted = append(x.Inserted, data)
 	return nil
 }

--- a/pkg/infra/bq/mock.go
+++ b/pkg/infra/bq/mock.go
@@ -31,6 +31,23 @@ func NewMock() *Mock {
 
 var _ interfaces.BigQuery = &Mock{}
 
+type MockStream struct {
+	Inserted [][]any
+}
+
+func (x *MockStream) Insert(ctx context.Context, data []any) error {
+	x.Inserted = append(x.Inserted, data)
+	return nil
+}
+
+func (x *MockStream) Close() error {
+	return nil
+}
+
+func (x *Mock) NewStream(ctx context.Context, datasetID types.BQDatasetID, tableID types.BQTableID, schema bigquery.Schema) (interfaces.BigQueryStream, error) {
+	return &MockStream{}, nil
+}
+
 func (x *Mock) Query(ctx context.Context, query string) (interfaces.BigQueryIterator, error) {
 	if x.MockQuery != nil {
 		return x.MockQuery(ctx, query)
@@ -64,8 +81,15 @@ func NewGeneralMock() *GeneralMock {
 }
 
 type GeneralMock struct {
-	Inserted     []MockInsertedData
-	Metadata     []*bigquery.TableMetadata
+	Metadata []*bigquery.TableMetadata
+
+	OpenedStream []struct {
+		Dataset types.BQDatasetID
+		Table   types.BQTableID
+		Schema  bigquery.Schema
+	}
+	Streams []*MockStream
+
 	CreatedTable []struct {
 		Dataset types.BQDatasetID
 		Table   types.BQTableID
@@ -110,18 +134,19 @@ func (x *GeneralMock) GetMetadata(ctx context.Context, dataset types.BQDatasetID
 	return md, nil
 }
 
-// Insert implements interfaces.BigQuery.
-func (x *GeneralMock) Insert(ctx context.Context, datasetID types.BQDatasetID, tableID types.BQTableID, schema bigquery.Schema, data []any) error {
+func (x *GeneralMock) NewStream(ctx context.Context, datasetID types.BQDatasetID, tableID types.BQTableID, schema bigquery.Schema) (interfaces.BigQueryStream, error) {
 	x.mutex.Lock()
 	defer x.mutex.Unlock()
 
-	x.Inserted = append(x.Inserted, MockInsertedData{
-		DatasetID: datasetID,
-		TableID:   tableID,
-		Schema:    schema,
-		Data:      data,
-	})
-	return nil
+	x.OpenedStream = append(x.OpenedStream, struct {
+		Dataset types.BQDatasetID
+		Table   types.BQTableID
+		Schema  bigquery.Schema
+	}{Dataset: datasetID, Table: tableID, Schema: schema})
+
+	s := &MockStream{}
+	x.Streams = append(x.Streams, s)
+	return s, nil
 }
 
 // Query implements interfaces.BigQuery.

--- a/pkg/infra/bq/stream.go
+++ b/pkg/infra/bq/stream.go
@@ -1,0 +1,116 @@
+package bq
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/m-mizutani/swarm/pkg/domain/types"
+	"github.com/m-mizutani/swarm/pkg/infra/bq/writer"
+
+	"cloud.google.com/go/bigquery"
+	mw "cloud.google.com/go/bigquery/storage/managedwriter"
+	"cloud.google.com/go/bigquery/storage/managedwriter/adapt"
+	"github.com/m-mizutani/goerr"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/dynamicpb"
+)
+
+type Stream struct {
+	datasetID     types.BQDatasetID
+	tableID       types.BQTableID
+	schema        bigquery.Schema
+	msgDescriptor protoreflect.MessageDescriptor
+
+	mgr *writer.Manager
+}
+
+func newStream(ctx context.Context, mwClient *mw.Client, projectID types.GoogleProjectID, datasetID types.BQDatasetID, tableID types.BQTableID, schema bigquery.Schema) (*Stream, error) {
+	convertedSchema, err := adapt.BQSchemaToStorageTableSchema(schema)
+	if err != nil {
+		return nil, goerr.Wrap(err, "failed to convert schema")
+	}
+
+	descriptor, err := adapt.StorageSchemaToProto2Descriptor(convertedSchema, "root")
+	if err != nil {
+		return nil, goerr.Wrap(err, "failed to convert schema to descriptor")
+	}
+	messageDescriptor, ok := descriptor.(protoreflect.MessageDescriptor)
+	if !ok {
+		return nil, goerr.Wrap(err, "adapted descriptor is not a message descriptor")
+	}
+	descriptorProto, err := adapt.NormalizeDescriptor(messageDescriptor)
+	if err != nil {
+		return nil, goerr.Wrap(err, "failed to normalize descriptor")
+	}
+
+	mgr, err := writer.NewManger(ctx, mwClient, descriptorProto, projectID, datasetID, tableID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Stream{
+		datasetID:     datasetID,
+		tableID:       tableID,
+		schema:        schema,
+		msgDescriptor: messageDescriptor,
+		mgr:           mgr,
+	}, nil
+}
+
+func (x *Stream) Insert(ctx context.Context, data []any) error {
+	var rows [][]byte
+	for _, v := range data {
+		message := dynamicpb.NewMessage(x.msgDescriptor)
+
+		raw, err := json.Marshal(v)
+		if err != nil {
+			return goerr.Wrap(err, "failed to Marshal json message").With("v", v)
+		}
+
+		// First, json->proto message
+		err = protojson.Unmarshal(raw, message)
+		if err != nil {
+			return goerr.Wrap(err, "failed to Unmarshal json message").With("raw", string(raw))
+		}
+		// Then, proto message -> bytes.
+		b, err := proto.Marshal(message)
+		if err != nil {
+			return goerr.Wrap(err, "failed to Marshal proto message")
+		}
+
+		rows = append(rows, b)
+	}
+
+	// After updating BigQuery schema, there is a delay for propagation of the schema change. According to the following document, it takes about 10 minutes.
+	// https://issuetracker.google.com/issues/64329577#comment3
+	// Then, we wait for 15 minutes to avoid the schema propagation delay.
+	ctx, cancel := context.WithTimeout(ctx, 15*time.Minute)
+	defer cancel()
+	if err := backoff(ctx, func(c int) (bool, error) {
+		w := x.mgr.Writer(ctx)
+		defer w.Release()
+
+		if err := w.Append(ctx, rows); err != nil {
+			if err == types.ErrSchemaNotMatched {
+				// If schema does not matched, it seems reconnection of stream is required
+				if err := x.mgr.Renew(ctx); err != nil {
+					return true, err // failed to renew stream, abort
+				}
+				return false, nil // retry
+			}
+		}
+
+		return true, nil // done without error
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (x *Stream) Close() error {
+	return x.mgr.Close()
+}

--- a/pkg/infra/bq/writer/manager.go
+++ b/pkg/infra/bq/writer/manager.go
@@ -1,0 +1,150 @@
+package writer
+
+import (
+	"context"
+	"io"
+	"sync"
+
+	"cloud.google.com/go/bigquery/storage/apiv1/storagepb"
+	mw "cloud.google.com/go/bigquery/storage/managedwriter"
+	"github.com/google/uuid"
+	"github.com/googleapis/gax-go/v2/apierror"
+	"github.com/m-mizutani/goerr"
+	"github.com/m-mizutani/swarm/pkg/domain/types"
+	"github.com/m-mizutani/swarm/pkg/utils"
+	"google.golang.org/protobuf/types/descriptorpb"
+)
+
+type Manager struct {
+	fac           *factory
+	currentWriter *writer
+	mutex         sync.Mutex
+	closeWG       sync.WaitGroup
+}
+
+type factory struct {
+	mwClient *mw.Client
+	proto    *descriptorpb.DescriptorProto
+
+	projectID types.GoogleProjectID
+	datasetID types.BQDatasetID
+	tableID   types.BQTableID
+}
+
+func (x *factory) newWriter(ctx context.Context) (*writer, error) {
+	ms, err := x.mwClient.NewManagedStream(ctx,
+		mw.WithDestinationTable(
+			mw.TableParentFromParts(
+				x.projectID.String(),
+				x.datasetID.String(),
+				x.tableID.String(),
+			),
+		),
+		// mw.WithType(mw.CommittedStream),
+		mw.WithSchemaDescriptor(x.proto),
+	)
+	if err != nil {
+		return nil, goerr.Wrap(err, "failed to create managed stream")
+	}
+
+	w := &writer{
+		id: uuid.NewString(),
+		s:  ms,
+	}
+	utils.CtxLogger(ctx).Debug("created new writer", "writer_id", w.id)
+	return w, nil
+}
+
+func NewManger(ctx context.Context, mwClient *mw.Client, proto *descriptorpb.DescriptorProto, projectID types.GoogleProjectID, datasetID types.BQDatasetID, tableID types.BQTableID) (*Manager, error) {
+	f := &factory{
+		mwClient: mwClient,
+		proto:    proto,
+
+		projectID: projectID,
+		datasetID: datasetID,
+		tableID:   tableID,
+	}
+
+	writer, err := f.newWriter(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Manager{
+		fac:           f,
+		currentWriter: writer,
+	}, nil
+}
+
+type writer struct {
+	id string
+	s  *mw.ManagedStream
+	wg sync.WaitGroup
+}
+
+func (x *Manager) Renew(ctx context.Context) error {
+	x.mutex.Lock()
+	defer x.mutex.Unlock()
+
+	newWriter, err := x.fac.newWriter(ctx)
+	if err != nil {
+		return err
+	}
+
+	oldWriter := x.currentWriter
+	utils.CtxLogger(ctx).Debug("renewing writer", "writer_id", oldWriter.id)
+	x.closeWG.Add(1)
+	go func() {
+		defer x.closeWG.Done()
+		oldWriter.wg.Wait()
+		utils.SafeClose(oldWriter.s)
+		utils.CtxLogger(ctx).Debug("closed writer", "writer_id", oldWriter.id)
+	}()
+
+	x.currentWriter = newWriter
+
+	return nil
+}
+
+func (x *Manager) Close() error {
+	x.mutex.Lock()
+	defer x.mutex.Unlock()
+	if err := x.currentWriter.s.Close(); err != nil && err != io.EOF {
+		return goerr.Wrap(err, "failed to close managed stream").With("writer_id", x.currentWriter.id)
+	}
+	x.currentWriter = nil
+	x.closeWG.Wait()
+	return nil
+}
+
+func (x *Manager) Writer(ctx context.Context) *writer {
+	x.mutex.Lock()
+	defer x.mutex.Unlock()
+
+	x.currentWriter.wg.Add(1)
+	return x.currentWriter
+}
+
+func (x *writer) Append(ctx context.Context, rows [][]byte) error {
+	arResult, err := x.s.AppendRows(ctx, rows)
+	if err != nil {
+		return goerr.Wrap(err, "failed to append rows")
+	}
+
+	if _, err := arResult.FullResponse(ctx); err != nil {
+		if apiErr, ok := apierror.FromError(err); ok {
+			storageErr := &storagepb.StorageError{}
+			if e := apiErr.Details().ExtractProtoMessage(storageErr); e == nil && storageErr.Code == storagepb.StorageError_SCHEMA_MISMATCH_EXTRA_FIELDS {
+				utils.CtxLogger(ctx).Debug("schema does not matched, should retry")
+				return types.ErrSchemaNotMatched
+			}
+		}
+		return goerr.Wrap(err, "failed to get append result")
+	}
+
+	return nil
+}
+
+func (x *writer) Release() {
+	x.wg.Done()
+}

--- a/pkg/infra/dump/client.go
+++ b/pkg/infra/dump/client.go
@@ -27,6 +27,22 @@ func (x *Client) GetMetadata(ctx context.Context, dataset types.BQDatasetID, tab
 	return &bigquery.TableMetadata{}, nil
 }
 
+func (x *Client) NewStream(ctx context.Context, datasetID types.BQDatasetID, tableID types.BQTableID, schema bigquery.Schema) (interfaces.BigQueryStream, error) {
+	return &Stream{}, nil
+}
+
+// TODO: Implement Stream
+type Stream struct {
+}
+
+func (x *Stream) Insert(ctx context.Context, data []any) error {
+	return nil
+}
+
+func (x *Stream) Close() error {
+	return nil
+}
+
 // Insert implements interfaces.BigQuery. It writes data to a file in JSON format. The file name is "{outDir}/{dataset}.{table}.log". If the file does not exist, it creates a new file. If the file exists, it appends data to the file. The file is not uploaded to BigQuery.
 func (x *Client) Insert(ctx context.Context, datasetID types.BQDatasetID, tableID types.BQTableID, schema bigquery.Schema, data []any) error {
 	fname := fmt.Sprintf("%s.%s.log", datasetID, tableID)

--- a/pkg/usecase/load.go
+++ b/pkg/usecase/load.go
@@ -68,9 +68,13 @@ func (x *UseCase) Load(ctx context.Context, requests []*model.LoadRequest) error
 		if err != nil {
 			return err
 		}
+		s, err := x.clients.BigQuery().NewStream(ctx, x.metadata.Dataset(), x.metadata.Table(), schema)
+		if err != nil {
+			return err
+		}
 
 		defer func() {
-			if err := x.clients.BigQuery().Insert(ctx, x.metadata.Dataset(), x.metadata.Table(), schema, []any{loadLog.Raw()}); err != nil {
+			if err := s.Insert(ctx, []any{loadLog.Raw()}); err != nil {
 				utils.HandleError(ctx, "failed to insert request log", err)
 			}
 		}()
@@ -321,6 +325,12 @@ func ingestRecords(ctx context.Context, bq interfaces.BigQuery, bqDst model.BigQ
 	close(recordsCh)
 
 	var wg sync.WaitGroup
+	stream, err := bq.NewStream(ctx, bqDst.Dataset, bqDst.Table, finalized)
+	if err != nil {
+		return result, err
+	}
+	defer utils.SafeClose(stream)
+
 	errCh := make(chan error)
 	for i := 0; i < concurrency; i++ {
 		wg.Add(1)
@@ -335,7 +345,7 @@ func ingestRecords(ctx context.Context, bq interfaces.BigQuery, bqDst model.BigQ
 				}
 
 				startedAt := time.Now()
-				if err := bq.Insert(ctx, bqDst.Dataset, bqDst.Table, finalized, data); err != nil {
+				if err := stream.Insert(ctx, data); err != nil {
 					errCh <- goerr.Wrap(err, "failed to insert data").With("dst", bqDst)
 				}
 				utils.CtxLogger(ctx).Debug("inserted data", "dst", bqDst, "count", len(data), "duration", time.Since(startedAt))

--- a/pkg/usecase/load_test.go
+++ b/pkg/usecase/load_test.go
@@ -135,8 +135,9 @@ func TestIngestRecordBigNum(t *testing.T) {
 		Table:   "test-table",
 	}
 
+	const dataSize = 32000
 	var records []*model.LogRecord
-	for i := 0; i < 1001; i++ {
+	for i := 0; i < dataSize; i++ {
 		records = append(records, &model.LogRecord{
 			ID:        types.LogID(uuid.NewString()),
 			Timestamp: time.Now(),
@@ -147,15 +148,14 @@ func TestIngestRecordBigNum(t *testing.T) {
 		})
 	}
 
-	resp := gt.R1(usecase.IngestRecords(ctx, bqMock, dst, records, 10)).NoError(t)
+	resp := gt.R1(usecase.IngestRecords(ctx, bqMock, dst, records, 32)).NoError(t)
 	gt.True(t, resp.Success)
 
 	gt.A(t, bqMock.Streams).Length(1).At(0, func(t testing.TB, stream *bq.MockStream) {
-		gt.A(t, stream.Inserted).Length(4)
 		total := 0
 		for _, r := range stream.Inserted {
 			total += len(r)
 		}
-		gt.Equal(t, total, 1001)
+		gt.Equal(t, total, dataSize)
 	})
 }


### PR DESCRIPTION
In previous implementation, swarm open and close managed stream each call of ingestion method. It's not good for performance. So, the PR changes interface of BigQuery client of swarm and uses one managed stream multiplexed 