### PR TITLE
Fix to ignore empty map when reducting

### DIFF
--- a/pkg/usecase/utils.go
+++ b/pkg/usecase/utils.go
@@ -31,6 +31,10 @@ func clone(fieldName string, src reflect.Value) (reflect.Value, bool) {
 		dst := reflect.New(src.Type())
 		t := src.Type()
 
+		if t.NumField() == 0 {
+			return src, false
+		}
+
 		for i := 0; i < t.NumField(); i++ {
 			f := t.Field(i)
 			srcValue := src.Field(i)
@@ -70,6 +74,10 @@ func clone(fieldName string, src reflect.Value) (reflect.Value, bool) {
 		return dst.Elem(), true
 
 	case reflect.Map:
+		if src.Len() == 0 {
+			return src, false
+		}
+
 		dst := reflect.MakeMap(src.Type())
 		keys := src.MapKeys()
 		for i := 0; i < src.Len(); i++ {

--- a/pkg/usecase/utils_test.go
+++ b/pkg/usecase/utils_test.go
@@ -51,6 +51,15 @@ func TestClone(t *testing.T) {
 			src:    []any{nil, "blue"},
 			expect: []any{"blue"},
 		},
+		"empty map": {
+			src: map[string]any{
+				"empty": map[string]any{},
+				"color": "blue",
+			},
+			expect: map[string]any{
+				"color": "blue",
+			},
+		},
 	}
 
 	for name, tc := range testCases {


### PR DESCRIPTION
This PR fixes insertion of the following data 

```json
{
  "data": {}
}
```