### PR TITLE
Enhance/job mode

### DIFF
--- a/pkg/controller/cmd/cli.go
+++ b/pkg/controller/cmd/cli.go
@@ -30,6 +30,7 @@ func Run(argv []string) error {
 		Commands: []*cli.Command{
 			ingestCommand(),
 			serveCommand(),
+			jobCommand(),
 			clientCommand(),
 			schemaCommand(),
 			enqueueCommand(),

--- a/pkg/controller/cmd/config/pubsub.go
+++ b/pkg/controller/cmd/config/pubsub.go
@@ -31,8 +31,8 @@ func (x *PubSub) Flags() []cli.Flag {
 	}
 }
 
-func (x *PubSub) Configure(ctx context.Context) (*pubsub.Client, error) {
-	client, err := pubsub.New(ctx, x.projectID, x.topicID)
+func (x *PubSub) Configure(ctx context.Context) (*pubsub.TopicClient, error) {
+	client, err := pubsub.NewTopic(ctx, x.projectID, x.topicID)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/cmd/enqueue.go
+++ b/pkg/controller/cmd/enqueue.go
@@ -51,7 +51,7 @@ func enqueueCommand() *cli.Command {
 			},
 		}, pubsubCfg.Flags()),
 		Action: func(ctx *cli.Context) error {
-			var pubsubClient interfaces.PubSub
+			var pubsubClient interfaces.PubSubTopic
 
 			utils.Logger().Info("Start enqueue command", "output", outDir)
 
@@ -71,7 +71,7 @@ func enqueueCommand() *cli.Command {
 			}
 
 			clients := infra.New(
-				infra.WithPubSub(pubsubClient),
+				infra.WithPubSubTopic(pubsubClient),
 				infra.WithCloudStorage(csClient),
 			)
 			uc := usecase.New(clients)

--- a/pkg/controller/cmd/job.go
+++ b/pkg/controller/cmd/job.go
@@ -1,0 +1,139 @@
+package cmd
+
+import (
+	"log/slog"
+
+	"github.com/m-mizutani/goerr"
+	"github.com/secmon-lab/swarm/pkg/controller/cmd/config"
+	"github.com/secmon-lab/swarm/pkg/infra"
+	"github.com/secmon-lab/swarm/pkg/infra/cs"
+	"github.com/secmon-lab/swarm/pkg/infra/pubsub"
+	"github.com/secmon-lab/swarm/pkg/usecase"
+	"github.com/secmon-lab/swarm/pkg/utils"
+	"github.com/urfave/cli/v2"
+)
+
+func jobCommand() *cli.Command {
+	var (
+		addr                    string
+		readConcurrency         int
+		ingestTableConcurrency  int
+		ingestRecordConcurrency int
+
+		bq       config.BigQuery
+		policy   config.Policy
+		metadata config.Metadata
+		sentry   config.Sentry
+
+		memoryLimit   string
+		subscriptions cli.StringSlice
+	)
+
+	return &cli.Command{
+		Name:  "job",
+		Usage: "Start swarm server",
+		Flags: mergeFlags([]cli.Flag{
+			&cli.IntFlag{
+				Name:        "read-concurrency",
+				EnvVars:     []string{"SWARM_READ_CONCURRENCY"},
+				Usage:       "Number of concurrent read from CloudStorage",
+				Destination: &readConcurrency,
+				Value:       32,
+			},
+			&cli.IntFlag{
+				Name:        "ingest-table-concurrency",
+				EnvVars:     []string{"SWARM_INGEST_TABLE_CONCURRENCY"},
+				Usage:       "Number of concurrent ingest to BigQuery (for tables)",
+				Destination: &ingestTableConcurrency,
+				Value:       16,
+			},
+			&cli.IntFlag{
+				Name:        "ingest-record-concurrency",
+				EnvVars:     []string{"SWARM_INGEST_RECORD_CONCURRENCY"},
+				Usage:       "Number of concurrent ingest to BigQuery (for tables)",
+				Destination: &ingestRecordConcurrency,
+				Value:       16,
+			},
+			&cli.StringFlag{
+				Name:        "memory-limit",
+				EnvVars:     []string{"SWARM_MEMORY_LIMIT"},
+				Usage:       "Memory limit for each process. If it exceeds the limit, the process return 429 too many requests error. (e.g. 1GiB)",
+				Destination: &memoryLimit,
+			},
+			&cli.StringSliceFlag{
+				Name:        "subscriptions",
+				Usage:       "Pub/Sub subscriptions to listen",
+				EnvVars:     []string{"SWARM_SUBSCRIPTIONS"},
+				Destination: &subscriptions,
+			},
+		}, bq.Flags(), policy.Flags(), metadata.Flags(), sentry.Flags()),
+
+		Action: func(c *cli.Context) error {
+			ctx := c.Context
+
+			utils.Logger().Info("starting server",
+				slog.Group("config",
+					"addr", addr,
+					"read-concurrency", readConcurrency,
+					"ingest-table-concurrency", ingestTableConcurrency,
+					"ingest-record-concurrency", ingestRecordConcurrency,
+					"memory-limit", memoryLimit,
+
+					"bigquery", &bq,
+					"policy", &policy,
+					"metadata", &metadata,
+					"sentry", &sentry,
+				),
+			)
+
+			if err := sentry.Configure(); err != nil {
+				return goerr.Wrap(err, "failed to configure sentry")
+			}
+
+			var infraOptions []infra.Option
+
+			policyClient, err := policy.Configure()
+			if err != nil {
+				return goerr.Wrap(err, "failed to configure policy client")
+			}
+			infraOptions = append(infraOptions, infra.WithPolicy(policyClient))
+
+			bqClient, err := bq.Configure(ctx)
+			if err != nil {
+				return goerr.Wrap(err, "failed to configure BigQuery client")
+			}
+			infraOptions = append(infraOptions, infra.WithBigQuery(bqClient))
+
+			csClient, err := cs.New(ctx)
+			if err != nil {
+				return goerr.Wrap(err, "failed to configure CloudStorage client")
+			}
+			infraOptions = append(infraOptions, infra.WithCloudStorage(csClient))
+
+			subClient, err := pubsub.NewSubscriptionClient(ctx)
+			if err != nil {
+				return goerr.Wrap(err, "failed to configure Pub/Sub subscription client")
+			}
+			infraOptions = append(infraOptions, infra.WithPubSubSubscription(subClient))
+
+			ucOptions := []usecase.Option{
+				usecase.WithIngestTableConcurrency(ingestTableConcurrency),
+				usecase.WithIngestRecordConcurrency(ingestRecordConcurrency),
+			}
+
+			if meta, err := metadata.Configure(); err != nil {
+				return goerr.Wrap(err, "failed to configure metadata")
+			} else if meta != nil {
+				ucOptions = append(ucOptions, usecase.WithMetadata(meta))
+			}
+
+			if readConcurrency > 0 {
+				ucOptions = append(ucOptions, usecase.WithReadObjectConcurrency(readConcurrency))
+			}
+
+			uc := usecase.New(infra.New(infraOptions...), ucOptions...)
+
+			return uc.RunWithSubscriptions(ctx, subscriptions.Value())
+		},
+	}
+}

--- a/pkg/domain/interfaces/infra.go
+++ b/pkg/domain/interfaces/infra.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/bigquery"
+	"cloud.google.com/go/pubsub/apiv1/pubsubpb"
 	"cloud.google.com/go/storage"
 	"github.com/secmon-lab/swarm/pkg/domain/model"
 	"github.com/secmon-lab/swarm/pkg/domain/types"
@@ -29,8 +30,15 @@ type BigQueryStream interface {
 	Close() error
 }
 
-type PubSub interface {
+type PubSubTopic interface {
 	Publish(ctx context.Context, data []byte) (types.PubSubMessageID, error)
+}
+
+type PubSubSubscription interface {
+	Pull(ctx context.Context, subName string) ([]*pubsubpb.ReceivedMessage, error)
+	ModifyAckDeadline(ctx context.Context, subName string, ackID string, deadline time.Duration) error
+	Acknowledge(ctx context.Context, subName string, ackID string) error
+	Close() error
 }
 
 type CSObjectIterator interface {

--- a/pkg/infra/clients.go
+++ b/pkg/infra/clients.go
@@ -8,7 +8,8 @@ import (
 type Clients struct {
 	bq     interfaces.BigQuery
 	cs     interfaces.CloudStorage
-	pubsub interfaces.PubSub
+	topic  interfaces.PubSubTopic
+	sub    interfaces.PubSubSubscription
 	policy *policy.Client
 	db     interfaces.Database
 }
@@ -24,9 +25,12 @@ func New(options ...Option) *Clients {
 
 func (x *Clients) BigQuery() interfaces.BigQuery         { return x.bq }
 func (x *Clients) CloudStorage() interfaces.CloudStorage { return x.cs }
-func (x *Clients) PubSub() interfaces.PubSub             { return x.pubsub }
-func (x *Clients) Policy() *policy.Client                { return x.policy }
-func (x *Clients) Database() interfaces.Database         { return x.db }
+func (x *Clients) PubSub() interfaces.PubSubTopic        { return x.topic }
+func (x *Clients) PubSubSubscription() interfaces.PubSubSubscription {
+	return x.sub
+}
+func (x *Clients) Policy() *policy.Client        { return x.policy }
+func (x *Clients) Database() interfaces.Database { return x.db }
 
 type Option func(*Clients)
 
@@ -42,9 +46,15 @@ func WithCloudStorage(cs interfaces.CloudStorage) Option {
 	}
 }
 
-func WithPubSub(pubsub interfaces.PubSub) Option {
+func WithPubSubTopic(topic interfaces.PubSubTopic) Option {
 	return func(c *Clients) {
-		c.pubsub = pubsub
+		c.topic = topic
+	}
+}
+
+func WithPubSubSubscription(sub interfaces.PubSubSubscription) Option {
+	return func(c *Clients) {
+		c.sub = sub
 	}
 }
 

--- a/pkg/infra/pubsub/client.go
+++ b/pkg/infra/pubsub/client.go
@@ -2,26 +2,98 @@ package pubsub
 
 import (
 	"context"
+	"time"
 
 	"cloud.google.com/go/pubsub"
+	apiv1 "cloud.google.com/go/pubsub/apiv1"
+	"cloud.google.com/go/pubsub/apiv1/pubsubpb"
+	"github.com/m-mizutani/goerr"
 	"github.com/secmon-lab/swarm/pkg/domain/types"
 )
 
-type Client struct {
-	topic *pubsub.Topic
+type TopicClient struct {
+	client *pubsub.Client
+	topic  *pubsub.Topic
 }
 
-func New(ctx context.Context, projectID types.GoogleProjectID, topicID types.PubSubTopicID) (*Client, error) {
+func NewTopic(ctx context.Context, projectID types.GoogleProjectID, topicID types.PubSubTopicID) (*TopicClient, error) {
 	client, err := pubsub.NewClient(ctx, projectID.String())
 	if err != nil {
 		return nil, err
 	}
 
 	topic := client.Topic(topicID.String())
-	return &Client{topic: topic}, nil
+	return &TopicClient{
+		client: client,
+		topic:  topic,
+	}, nil
 }
 
-func (x *Client) Publish(ctx context.Context, data []byte) (types.PubSubMessageID, error) {
+func (x *TopicClient) Publish(ctx context.Context, data []byte) (types.PubSubMessageID, error) {
 	msgID, err := x.topic.Publish(ctx, &pubsub.Message{Data: data}).Get(ctx)
 	return types.PubSubMessageID(msgID), err
+}
+
+func (x *TopicClient) Close() {
+	x.topic.Stop()
+	x.client.Close()
+}
+
+type SubscriptionClient struct {
+	client *apiv1.SubscriberClient
+}
+
+func NewSubscriptionClient(ctx context.Context) (*SubscriptionClient, error) {
+	client, err := apiv1.NewSubscriberClient(ctx)
+	if err != nil {
+		return nil, goerr.Wrap(err, "failed to create subscriber client")
+	}
+
+	return &SubscriptionClient{
+		client: client,
+	}, nil
+}
+
+func (x *SubscriptionClient) Pull(ctx context.Context, subName string) ([]*pubsubpb.ReceivedMessage, error) {
+	req := pubsubpb.PullRequest{
+		Subscription:      subName,
+		MaxMessages:       1,
+		ReturnImmediately: true,
+	}
+
+	res, err := x.client.Pull(ctx, &req)
+	if err != nil {
+		return nil, goerr.Wrap(err, "failed to pull message").With("subName", subName)
+	}
+
+	return res.ReceivedMessages, nil
+}
+
+func (x *SubscriptionClient) Acknowledge(ctx context.Context, subName string, ackID string) error {
+	req := pubsubpb.AcknowledgeRequest{
+		Subscription: subName,
+		AckIds:       []string{ackID},
+	}
+
+	if err := x.client.Acknowledge(ctx, &req); err != nil {
+		return goerr.Wrap(err, "failed to acknowledge message").With("subName", subName).With("ackID", ackID)
+	}
+	return nil
+}
+
+func (x *SubscriptionClient) ModifyAckDeadline(ctx context.Context, subName string, ackID string, deadline time.Duration) error {
+	req := pubsubpb.ModifyAckDeadlineRequest{
+		Subscription:       subName,
+		AckIds:             []string{ackID},
+		AckDeadlineSeconds: int32(deadline.Seconds()),
+	}
+
+	if err := x.client.ModifyAckDeadline(ctx, &req); err != nil {
+		return goerr.Wrap(err, "failed to modify ack deadline").With("subName", subName).With("ackID", ackID).With("deadline", deadline)
+	}
+	return nil
+}
+
+func (x *SubscriptionClient) Close() error {
+	return x.client.Close()
 }

--- a/pkg/usecase/enqueue.go
+++ b/pkg/usecase/enqueue.go
@@ -86,7 +86,7 @@ func sumObjectSize(newOjb *model.Object, objects ...*model.Object) int64 {
 	return sum
 }
 
-func enqueueObjects(ctx context.Context, client interfaces.PubSub, objects []*model.Object) error {
+func enqueueObjects(ctx context.Context, client interfaces.PubSubTopic, objects []*model.Object) error {
 	msg := model.SwarmMessage{
 		Objects: objects,
 	}

--- a/pkg/usecase/enqueue_test.go
+++ b/pkg/usecase/enqueue_test.go
@@ -42,7 +42,7 @@ func TestEnqueue(t *testing.T) {
 
 	uc := usecase.New(infra.New(
 		infra.WithCloudStorage(csMock),
-		infra.WithPubSub(pubsubMock),
+		infra.WithPubSubTopic(pubsubMock),
 	))
 
 	req := &model.EnqueueRequest{

--- a/pkg/usecase/job.go
+++ b/pkg/usecase/job.go
@@ -1,0 +1,116 @@
+package usecase
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"cloud.google.com/go/pubsub/apiv1/pubsubpb"
+	"github.com/m-mizutani/goerr"
+	"github.com/secmon-lab/swarm/pkg/domain/interfaces"
+	"github.com/secmon-lab/swarm/pkg/domain/model"
+	"github.com/secmon-lab/swarm/pkg/utils"
+)
+
+func (x *UseCase) RunWithSubscriptions(ctx context.Context, subscriptions []string) error {
+	utils.Logger().Info("starting job", "subscriptions", subscriptions)
+
+	for _, subName := range subscriptions {
+		if err := x.runWithSubscription(ctx, subName); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (x *UseCase) runWithSubscription(ctx context.Context, subName string) error {
+	utils.Logger().Info("starting job", "subscription", subName)
+
+	pullClient := x.clients.PubSubSubscription()
+	for {
+		resp, err := pullClient.Pull(ctx, subName)
+		if err != nil {
+			return err
+		}
+		if len(resp) == 0 {
+			utils.Logger().Info("no message in subscription", "subscription", subName)
+			return nil
+		}
+
+		for _, msg := range resp {
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			go func() {
+				if err := loopExtendPubSubMessageDeadline(ctx, pullClient, subName, msg.AckId); err != nil {
+					utils.Logger().Error("failed to extend deadline", "error", err)
+				}
+			}()
+
+			if err := x.processPubSubMessage(ctx, msg); err != nil {
+				return err
+			}
+
+			if err := pullClient.Acknowledge(ctx, subName, msg.AckId); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func loopExtendPubSubMessageDeadline(ctx context.Context, client interfaces.PubSubSubscription, subName string, ackID string) error {
+	tickInterval := 60 * time.Second
+	extendDuration := 90 * time.Second
+
+	tick := time.NewTicker(tickInterval)
+	defer tick.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			if ctx.Err() == context.Canceled {
+				return nil
+			}
+			return ctx.Err()
+
+		case <-tick.C:
+			if err := client.ModifyAckDeadline(ctx, subName, ackID, extendDuration); err != nil {
+				return err
+			}
+		}
+	}
+
+}
+
+func (x *UseCase) processPubSubMessage(ctx context.Context, msg *pubsubpb.ReceivedMessage) error {
+	logger := utils.Logger()
+	logger.Info("processing message", "message", msg)
+
+	// Decode message
+	var event model.CloudStorageEvent
+	if err := json.Unmarshal(msg.Message.Data, &event); err != nil {
+		return err
+	}
+	logger.Info("decoded message", "event", event)
+
+	obj := event.ToObject()
+	sources, err := x.ObjectToSources(ctx, obj)
+	if err != nil {
+		return goerr.Wrap(err, "failed to convert event to sources").With("event", event)
+	}
+
+	loadReq := make([]*model.LoadRequest, len(sources))
+	for i := range sources {
+		loadReq[i] = &model.LoadRequest{
+			Object: event.ToObject(),
+			Source: *sources[i],
+		}
+	}
+
+	if err := x.Load(ctx, loadReq); err != nil {
+		return goerr.Wrap(err).With("event", event)
+	}
+
+	return nil
+}

--- a/pkg/usecase/job.go
+++ b/pkg/usecase/job.go
@@ -75,12 +75,12 @@ func loopExtendPubSubMessageDeadline(ctx context.Context, client interfaces.PubS
 			return ctx.Err()
 
 		case <-tick.C:
+			utils.Logger().Info("extend deadline", "subscription", subName, "ackID", ackID)
 			if err := client.ModifyAckDeadline(ctx, subName, ackID, extendDuration); err != nil {
 				return err
 			}
 		}
 	}
-
 }
 
 func (x *UseCase) processPubSubMessage(ctx context.Context, msg *pubsubpb.ReceivedMessage) error {


### PR DESCRIPTION
This pull request introduces a new `jobCommand` and makes significant changes to the Pub/Sub client structure in the `pkg/controller` package. The most important changes include adding the `jobCommand`, modifying the Pub/Sub client interfaces, and updating the `enqueueCommand` to use the new Pub/Sub client structure.

### Additions:
* Added a new `jobCommand` to the `pkg/controller/cmd/job.go` file, which includes various configurations and starts a server for processing jobs.

### Pub/Sub Client Structure Modifications:
* Changed the `PubSub` interface to `PubSubTopic` and added a new `PubSubSubscription` interface in `pkg/domain/interfaces/infra.go`.
* Updated the `pkg/infra/pubsub/client.go` file to include `TopicClient` and `SubscriptionClient` structs, with methods for publishing, pulling, acknowledging, and modifying Pub/Sub messages.

### Updates to Existing Commands:
* Modified the `enqueueCommand` to use the new `PubSubTopic` client instead of the old `PubSub` client in `pkg/controller/cmd/enqueue.go`. [[1]](diffhunk://#diff-a38d98a789eb3ed0d1e94432bb5f1617565c741f15e9aa3510025b95a19a9916L54-R54) [[2]](diffhunk://#diff-a38d98a789eb3ed0d1e94432bb5f1617565c741f15e9aa3510025b95a19a9916L74-R74)
* Updated the `enqueueObjects` function in `pkg/usecase/enqueue.go` to use the new `PubSubTopic` client.

### Additional Changes:
* Added a new `RunWithSubscriptions` method in `pkg/usecase/job.go` to handle Pub/Sub subscriptions and process messages.